### PR TITLE
a few minor details

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -38,7 +38,7 @@ function tsml_alert_messages() {
 //function: enqueue assets for public or admin page
 //used: in templates and on admin_edit.php
 function tsml_assets() {
-	global $tsml_types, $tsml_strings, $tsml_program, $tsml_google_api_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults;
+	global $tsml_street_only, $tsml_types, $tsml_strings, $tsml_program, $tsml_google_api_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults;
 		
 	//google maps api needed for maps and address verification, can't be onboarded
 	wp_enqueue_script('google_maps_api', '//maps.googleapis.com/maps/api/js?key=' . $tsml_google_api_key);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -243,8 +243,10 @@ function tsml_format_address($formatted_address, $street_only=false) {
 	$parts = array_map('trim', $parts);
 	if (in_array(end($parts), array('USA', 'US'))) {
 		array_pop($parts);
-		$state_zip = array_pop($parts);
-		$parts[count($parts) - 1] .= ', ' . $state_zip;
+		if (count($parts) > 1) {
+			$state_zip = array_pop($parts);
+			$parts[count($parts) - 1] .= ', ' . $state_zip;
+		}
 	}
 	if ($street_only) return array_shift($parts);
 	return implode('<br>', $parts);

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -4,6 +4,8 @@ don't make changes! it'll make staying updated much harder.
 for updates / questions, please contact wordpress@meetingguide.org
 */
 
+$tsml_street_only = true;
+
 $tsml_alerts = array();
 
 $tsml_days	= array(

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -285,7 +285,7 @@ class Walker_Regions_Dropdown extends Walker_Category {
 							<td class="location" data-sort="<?php echo sanitize_title($meeting['location']) . '-' . $sort_time?>">
 								<?php echo $meeting['location']?>
 							</td>
-							<td class="address" data-sort="<?php echo sanitize_title($meeting['formatted_address']) . '-' . $sort_time?>"><?php echo tsml_format_address($meeting['formatted_address'], true)?></td>
+							<td class="address" data-sort="<?php echo sanitize_title($meeting['formatted_address']) . '-' . $sort_time?>"><?php echo tsml_format_address($meeting['formatted_address'], $tsml_street_only)?></td>
 							<td class="region" data-sort="<?php echo sanitize_title($meeting['region']) . '-' . $sort_time?>"><?php echo $meeting['region']?></td>
 							<td class="types" data-sort="<?php echo sanitize_title(tsml_meeting_types($meeting['types'])) . '-' . $sort_time?>"><?php echo tsml_meeting_types($meeting['types'])?></td>
 						</tr>


### PR DESCRIPTION
For our purposes we would like to display the full address in the meeting list "archive".

In the course of this I noted a logic error in functions.php (line 246-247) and created a new global variable $tsml_street_only, which is used by the $street_only variable in the JS for address formatting.
Right now it's hard-coded into archive-meetings.php (line 290).

With these changes, I can now include this line in my child theme's functions.php:

$tsml_street_only = false;

... to override the default of true in variables.php

I know I could simply copy over archive-meetings.php and change line 290, but this seems more flexible to me and doesn't require me to do the change each time you update archive-meetings.php (which seems to be often).

Thanks for your service,

John