### PR TITLE
Adding user-defined header to meeting list (archive) page

### DIFF
--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -2,7 +2,7 @@
 	
 //import CSV file and handle settings
 function tmsl_import_page() {
-	global $wpdb, $tsml_types, $tsml_programs, $tsml_program, $tsml_nonce, $tsml_days, $tsml_feedback_addresses, $tsml_notification_addresses, $tsml_distance_units;
+	global $wpdb, $tsml_types, $tsml_programs, $tsml_program, $tsml_nonce, $tsml_days, $tsml_feedback_addresses, $tsml_notification_addresses, $tsml_distance_units, $tsml_archive_header;
 
 	$error = false;
 	
@@ -231,7 +231,14 @@ function tmsl_import_page() {
 		update_option('tsml_program', $tsml_program);
 		tsml_alert(__('Program setting updated.', '12-step-meeting-list'));
 	}
-		
+	
+	// set archives page header
+		if (!empty($_POST['tsml_archive_header_submit']) && isset($_POST['tsml_nonce']) && wp_verify_nonce($_POST['tsml_nonce'], $tsml_nonce)) {
+		$tsml_archive_header = ($_POST['tsml_archive_header']);
+		update_option('tsml_archive_header', $tsml_archive_header);
+		tsml_alert(__('Header content updated.', '12-step-meeting-list'));
+	}
+	
 	//change distance units
 	if (!empty($_POST['tsml_distance_units']) && isset($_POST['tsml_nonce']) && wp_verify_nonce($_POST['tsml_nonce'], $tsml_nonce)) {
 		$tsml_distance_units = ($_POST['tsml_distance_units'] == 'mi') ? 'mi' : 'km';
@@ -313,10 +320,27 @@ function tmsl_import_page() {
 					
 					<div class="postbox">
 						<div class="inside">
+							<h3><?php _e('Create Meeting List Page Header', '12-step-meeting-list')?></h3>
+							<p>Below, you may enter any text you would like to appear above the meeting list. HTML codes are accepted.</p>
+							<form method="post" action="edit.php?post_type=tsml_meeting&page=import">
+								<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
+								<div class="meta_form_row">
+									<label for="content">Header Content</label>
+									<textarea name="tsml_archive_header" id="content" placeholder="Example: Click &lt;a href=&quot;explain&quot;&gt;here&lt;/a&gt; for an explanation of the types of meetings."><?php 
+										$tsml_archive_header = get_option('tsml_archive_header', '');
+										echo (esc_html($tsml_archive_header));
+									?></textarea>
+								</div>
+								<p class="submit"><input type="submit" name="tsml_archive_header_submit" id="submit" class="button button-primary" value="Update Header Content"  /></p>
+							</form>
+						</div>
+					</div>
+					<div class="postbox">
+						<div class="inside">
 							<h3><?php _e('Import CSV', '12-step-meeting-list')?></h3>
 							<form method="post" action="edit.php?post_type=tsml_meeting&page=import" enctype="multipart/form-data">
 								<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
-								<input type="file" name="tsml_import"></textarea>
+								<input type="file" name="tsml_import">
 								<p>
 									<?php _e('When importing...', '12-step-meeting-list')?><br>
 									<?php if (empty($_POST['delete'])) $_POST['delete'] = 'nothing'?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -38,7 +38,7 @@ function tsml_alert_messages() {
 //function: enqueue assets for public or admin page
 //used: in templates and on admin_edit.php
 function tsml_assets() {
-	global $tsml_street_only, $tsml_types, $tsml_strings, $tsml_program, $tsml_google_api_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults;
+	global $tsml_street_only, $tsml_types, $tsml_strings, $tsml_program, $tsml_google_api_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults, $tsml_archive_header;
 		
 	//google maps api needed for maps and address verification, can't be onboarded
 	wp_enqueue_script('google_maps_api', '//maps.googleapis.com/maps/api/js?key=' . $tsml_google_api_key);
@@ -74,6 +74,7 @@ function tsml_assets() {
 			'strings' => $tsml_strings,
 			'street_only' => $tsml_street_only,
 			'types' => $tsml_types[$tsml_program],
+			'archive_header' => $tsml_archive_header,
 		));
 	}
 }

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -34,6 +34,8 @@ $tsml_defaults = array(
 
 $tsml_distance_units = get_option('tsml_distance_units', 'mi');
 
+$tsml_archive_header = get_option('tsml_archive_header', '');
+
 $tsml_feedback_addresses = get_option('tsml_feedback_addresses', array());
 
 $tsml_google_api_key = 'AIzaSyCC3p6PSf6iQbXi-Itwn9C24_FhkbDUkdg'; //might have to make this user-specific

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -106,6 +106,9 @@ class Walker_Regions_Dropdown extends Walker_Category {
 
 ?>
 <div id="tsml">
+	<div id="tsml_archive_header" class="tsml_archive_header">
+		<?php echo ($tsml_archive_header); ?>
+	</div>
 	<div id="meetings" data-view="<?php echo $view?>" data-mode="<?php echo $mode?>" class="container<?php if (!count($meetings)) {?> empty<?php }?>" role="main">
 		<div class="row controls hidden-print">
 			<div class="col-sm-6 col-md-2">


### PR DESCRIPTION
This is a feature I was looking for, and turned out not to be too hard to implement. The user can create an arbitrary header that displays above the meeting list. In my case I add the `<h1>` tag that is at the top of all the other pages on my site, as well as a Key to define Closed, Open, Chips, etc. Others can create their own.