### PR TITLE
Added support for showing featured image on a meeting page

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -187,7 +187,7 @@ if (!function_exists('tsml_custom_post_types')) {
 					'edit_item' =>	__('Edit Meeting', '12-step-meeting-list'),
 					'view_item' =>	__('View Meeting', '12-step-meeting-list'),
 				),
-				'supports' => array('title'),
+				'supports' => array('title', 'thumbnail'),
 				'public' => true,
 				'has_archive' => true,
 				'menu_icon' => 'dashicons-groups',

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -246,6 +246,9 @@ get_header();
 						
 					</div>
 					<div class="col-md-8">
+						<?php if(has_post_thumbnail()) { ?>
+							<img src="<?php echo get_the_post_thumbnail_url(); ?>" class="panel panel-default meeting-thumbnail img-responsive">
+						<?php } ?>
 						<div id="map" class="panel panel-default"></div>
 					</div>
 				</div>


### PR DESCRIPTION
This feature allows users to upload a featured image to a meeting, which is then displayed above the map on single meeting pages. 