### PR TITLE
Fix translation issues

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -11,9 +11,6 @@ function tsml_init() {
 	//run any necessary upgrades
 	tsml_upgrades();
 	
-	//load internationalization
-	load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');
-	
 	//meeting list page
 	add_filter('archive_template', 'tsml_archive_template');
 	function tsml_archive_template($template) {

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -187,6 +187,9 @@ add_action('plugins_loaded', 'tsml_define_strings');
 function tsml_define_strings() {
 	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_program, $tsml_strings, $tsml_types_in_use;
 
+        //load internationalization
+        load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');
+
 	//days of the week
 	$tsml_days	= array(
 		__('Sunday', '12-step-meeting-list'),


### PR DESCRIPTION
Some things were correctly translating, but most things were not.
Especially on the admin panel.

The issue seemed to be loading the load_plugin_textdomain in the
init hook in the file init.php doesn't work correctly.
Moved it to the file variables.php in the plugins_loaded hook.
The translations now load at the correct time in the
initialization sequence and tests are successful.