### PR TITLE
Import from Meeting Guide Format Google Sheet

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1021,6 +1021,10 @@ function tsml_meeting_types($types) {
 //called from admin_import.php (both CSV and JSON)
 function tsml_import_buffer_set($meetings, $data_source=null) {
 	global $tsml_programs, $tsml_program, $tsml_days;
+
+	if (strpos($data_source, "spreadsheets.google.com") !== false){
+		$meetings = tsml_import_reformat_googlesheet($meetings);
+	}
 	
 	//uppercasing for value matching later
 	$upper_types = array_map('strtoupper', $tsml_programs[$tsml_program]['types']);
@@ -1302,6 +1306,28 @@ function tsml_import_reformat_fnv($rows) {
 		$return[] = array_values($meeting);
 	}
 	return $return;
+}
+
+//function: translates a Meeting Guide format Google Sheet to proper format for import
+//used: tsml_import_buffer_set
+function tsml_import_reformat_googlesheet($data) {
+	$meetings = [];
+
+	for ($i=0; $i < count($data['feed']['entry']); $i++) {
+
+		//creates a meeting array with elements corresponding to each column header of the Google Sheet
+		$meeting = [];
+		$meetingKeys = array_keys($data['feed']['entry'][$i]);
+		for ($j=0; $j < count($meetingKeys); $j++) {
+			if (substr($meetingKeys[$j], 0, 4) == "gsx$") {
+				$meeting[substr($meetingKeys[$j], 4)] = $data['feed']['entry'][$i][$meetingKeys[$j]]['$t'];
+			}
+		}
+
+		array_push($meetings, $meeting);
+	}
+
+	return $meetings;
 }
 
 //function: turn "string" into string


### PR DESCRIPTION
This commit allows you to enter the Google Sheet JSON url as a data source to import. It uses the same algorithm created for the spreadsheet.js project that I modified for the react project and then redid here in PHP.

I wasn't sure of the best place to put the function so just placed it alphabetically inside the includes/function.php file. I also wasn't sure of the best place to call the function (maybe somewhere in admin_import.php ???) but just did it at the start of the tsml_import_buffer_set function and it worked perfectly.

I was actually really surprised, compared to my work on implementing this same feature in the react app, that the WordPress plugin handled (as far as I can tell) all the necessary secondary processing such as creating a slug if none provided, dealing with the time including an am/pm, and processing the types being written out. Clearly that work has already been baked in for the importing from a CSV.